### PR TITLE
Add semicolon comment support

### DIFF
--- a/syntaxes/exa.tmLanguage.json
+++ b/syntaxes/exa.tmLanguage.json
@@ -25,7 +25,7 @@
     "comments": {
       "patterns": [
         {
-          "match": "NOTE.*",
+          "match": "^[NOTE,;].*",
           "name": "comment.line.character.exa"
         }
       ]


### PR DESCRIPTION
Thanks for the extension, added `;` for comments since it's supported in the instruction set.