### PR TITLE
Fix regex issue with some instructions

### DIFF
--- a/syntaxes/exa.tmLanguage.json
+++ b/syntaxes/exa.tmLanguage.json
@@ -25,7 +25,7 @@
     "comments": {
       "patterns": [
         {
-          "match": "^[NOTE,;].*",
+          "match": "NOTE.*|;.*",
           "name": "comment.line.character.exa"
         }
       ]

--- a/syntaxes/exa.tmLanguage.json
+++ b/syntaxes/exa.tmLanguage.json
@@ -25,7 +25,7 @@
     "comments": {
       "patterns": [
         {
-          "match": "NOTE.*|;.*",
+          "match": "(NOTE|;).*",
           "name": "comment.line.character.exa"
         }
       ]


### PR DESCRIPTION
The previous regex added support for comments with `;`, but created an issue with `TEST` and `TJMP` instructions being interpreted as comments too. This patch addresses the issue.